### PR TITLE
Nextflow module + docs: pin arda-mapper 2.5.3

### DIFF
--- a/docs/pipeline_integration.rst
+++ b/docs/pipeline_integration.rst
@@ -60,7 +60,7 @@ unchanged. Five edits, each mirroring how an existing tool is wired:
    ``workflows/rnaseq/nextflow.config`` (sets ``ext.args`` and the publishDir).
 #. Register a ``run_arda = false`` param in ``nextflow.config`` and ``nextflow_schema.json`` (strict
    schema validation).
-#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.1' }``
+#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.3' }``
    in your deployment config.
 
 Then run with ``--run_arda``. The module's ``README.md`` has copy-paste snippets and a standalone

--- a/integrations/nextflow/arda/Dockerfile
+++ b/integrations/nextflow/arda/Dockerfile
@@ -2,9 +2,9 @@
 # Build and push to your own registry (e.g. the ISPRAS private registry), then point the module's
 # `container` directive (or a withName override in your nextflow.config) at the pushed tag:
 #
-#   docker build -t arda-mapper:2.5.1 integrations/nextflow/arda
-#   docker tag arda-mapper:2.5.1 <your-registry>/arda-mapper:2.5.1
-#   docker push <your-registry>/arda-mapper:2.5.1
+#   docker build -t arda-mapper:2.5.3 integrations/nextflow/arda
+#   docker tag arda-mapper:2.5.3 <your-registry>/arda-mapper:2.5.3
+#   docker push <your-registry>/arda-mapper:2.5.3
 #
 FROM mambaorg/micromamba:1.5.8
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml

--- a/integrations/nextflow/arda/README.md
+++ b/integrations/nextflow/arda/README.md
@@ -90,7 +90,7 @@ changes. Five edits, all mirroring how an existing tool is wired:
    (copy any existing `skip_*`/`run_*` boolean entry as a template).
 
 5. **Container override** (only for `-profile docker/singularity/<your-profile>`): add
-   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.1' }` to your deployment config
+   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.3' }` to your deployment config
    (e.g. `conf/<profile>.config`), exactly as the other tools' images are pinned there.
 
 Run with `--run_arda`:

--- a/integrations/nextflow/arda/environment.yml
+++ b/integrations/nextflow/arda/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - pip:
       # [rnaseq] pulls seqtree, which `arda rnaseq correct` needs. Without it the run dies
       # after writing the AIRR, before any clonotype table is produced.
-      - arda-mapper[rnaseq]==2.5.1
+      - arda-mapper[rnaseq]==2.5.3

--- a/integrations/nextflow/arda/main.nf
+++ b/integrations/nextflow/arda/main.nf
@@ -13,7 +13,7 @@ process ARDA {
     //   -profile docker   -> build the image from the Dockerfile beside this module and push it to
     //                        your registry, then point `container` at it (or override in a config).
     conda "${moduleDir}/environment.yml"
-    container "arda-mapper:2.5.1"
+    container "arda-mapper:2.5.3"
 
     input:
     tuple val(meta), path(reads)


### PR DESCRIPTION
The module still installed **2.5.1**, whose reference builds scaffolds from 3′-truncated V alleles —
so a collaborator following the integration docs would have got junctions short by up to 3 aa on the
affected genes, **silently**. This is the delivery path for the Gamaleya/ISP integration, so the pin
matters.

Bumped: `environment.yml`, the `container` tag, the `Dockerfile` build commands, the module README,
and `docs/pipeline_integration.rst`.

## Verified against the published 2.5.3, not just bumped

- Clean venv + empty `XDG_CACHE_HOME` → auto-fetches the **v2.5.3** release asset: **16,035
  scaffolds** (2.5.2 shipped 17,668), **0 junctions not starting at Cys104** (2.5.2 shipped 570),
  `TRAV20*03` absent.
- The module run through **Nextflow 26.04.6** publishes a `clones.tsv` **identical** to the
  standalone run and to the committed `examples/rnaseq/clones.tsv`.
- `airr` emits one file, contigs land on `assembled_airr`, and `versions.yml` reports `arda: 2.5.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)