### PR TITLE
docs CI: install seqtree (fixes the failing docs build on master)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install docs toolchain
         # autodoc imports arda from ../src with the C++ ext + typer/requests mocked (see
         # docs/conf.py); polars is imported at module level by the rnaseq API (real, not mockable).
-        run: pip install sphinx pydata-sphinx-theme nbsphinx polars
+        run: pip install sphinx pydata-sphinx-theme nbsphinx polars seqtree
       - name: Build HTML (fail on warnings)
         run: sphinx-build -W --keep-going -b html docs docs/_build/html
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Making `seqtree` a core dependency (2.5.5) moved its import to the top of `rnaseq.correct`, so
autodoc now needs it importable. The docs workflow installed only `sphinx pydata-sphinx-theme
nbsphinx polars`, and the build failed on master:

```
WARNING: autodoc: failed to import 'correct' from module 'arda.rnaseq';
ModuleNotFoundError: No module named 'seqtree'
```

(`sphinx-build -W` turns that warning into a failure, which is the point of the gate.)

**Installed, not mocked** — for the same reason `polars` is: both are imported at *module* level by
the rnaseq API, and autodoc cannot document a mock.

Verified: `sphinx-build -W --keep-going` builds clean locally with seqtree present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)