### PR TITLE
Correct the memory guidance: peak RSS tracks repertoire richness, not read depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ box) and a `Dockerfile`, and emits a `versions.yml`. See its
 [README](integrations/nextflow/arda/README.md) and the
 [pipeline-integration guide](https://docs.isalgo.dev/arda/pipeline_integration.html) for the five-line drop-in.
 
-arda is **CPU-bound and low-memory**: ~40k reads/s on 32 cores (~2.4 M reads/min, < 400 MB RAM), so a
-full-depth bulk RNA-seq sample of ~50 M read pairs finishes in ~45 min. Throughput scales with cores.
+arda is **CPU-bound**: ~40–50k reads/s on 32 cores, so a full-depth bulk RNA-seq sample (~50 M read
+pairs) finishes in ~45 min. Throughput scales with cores. Peak memory tracks **repertoire richness**,
+not read depth — mapping is flat (~300–400 MB at any depth), while Stage 3 holds the clone set, so a
+B-cell-rich tumour peaked at 2.7 GB (28k clonotypes) and a colder sample with *more* reads used 314 MB.
+Budget ~4 GB.
 
 ## Library
 

--- a/docs/pipeline_integration.rst
+++ b/docs/pipeline_integration.rst
@@ -69,8 +69,8 @@ one-process test harness.
 Runtime & resources
 ~~~~~~~~~~~~~~~~~~~~~
 
-arda is **CPU-bound** (the MMseqs2 search dominates) and **very low-memory** (< 400 MB peak RSS,
-independent of read depth). Give it cores, not RAM. Measured on bulk tumor RNA-seq at 32 cores:
+arda is **CPU-bound** — the MMseqs2 search dominates — so give it cores. Measured on bulk tumor
+RNA-seq at 32 cores, ``arda rnaseq run --assemble`` (map + assemble + correct):
 
 .. list-table::
    :header-rows: 1
@@ -80,15 +80,36 @@ independent of read depth). Give it cores, not RAM. Measured on bulk tumor RNA-s
      - wall time
      - throughput
      - peak RSS
-   * - 104.9 M (52.4 M pairs, 2×150)
+     - clonotypes
+   * - 104.9 M (2×150)
      - 32
-     - 44 min
-     - ~39,600 reads/s (2.4 M/min)
-     - 371 MB
+     - 46 min
+     - ~38,300 reads/s
+     - 2,707 MB
+     - 28,444
+   * - 153.9 M (2×100)
+     - 32
+     - 51 min
+     - ~50,300 reads/s
+     - 511 MB
+     - 1,519
+   * - 138.5 M (2×100)
+     - 32
+     - 45 min
+     - ~51,900 reads/s
+     - 314 MB
+     - 30
 
-Throughput scales roughly linearly with cores; a typical full-depth bulk RNA-seq sample (~50 M read
-pairs) takes ~45 min on 32 cores. The Nextflow module is labelled ``process_high``; raise it with
+Throughput scales roughly linearly with cores; a typical full-depth bulk RNA-seq sample takes ~45 min
+on 32 cores. The Nextflow module is labelled ``process_high``; raise it with
 ``withName: 'ARDA' { cpus = 32 }`` for full-depth data. ``--threads`` follows ``task.cpus``.
+
+**Peak memory tracks repertoire richness, not read depth.** The third sample above has *more* reads
+than the first yet uses 9× less RAM — it carries 30 clonotypes against 28,444. Mapping alone is flat
+and small (~300–400 MB at any depth); it is Stage 3 (assembly + error correction) that holds the clone
+set in memory. Budget **~4 GB** for a lymphocyte- or B-cell-rich sample and ~1 GB for a cold one. Under
+a hard memory cap, ``--no-assemble`` restores the flat mapping-only profile — at the cost of the long
+CDR3s that no single read spans.
 
 Tuning
 ~~~~~~~

--- a/integrations/nextflow/arda/README.md
+++ b/integrations/nextflow/arda/README.md
@@ -16,16 +16,24 @@ pipeline the same way STAR/Salmon/fastp do.
 
 ## Runtime & resources
 
-arda is **CPU-bound** (the MMseqs2 search dominates) and **very low-memory** (< 400 MB peak RSS,
-independent of read depth) — so give the process cores, not RAM. Measured on bulk tumor RNA-seq,
-32 cores:
+arda is **CPU-bound** — the MMseqs2 search dominates — so give the process cores. Measured on bulk
+tumor RNA-seq, 32 cores, `arda rnaseq run --assemble` (map + assemble + correct):
 
-| reads | cores | wall time | throughput | peak RSS |
-|---|---|---|---|---|
-| 104.9 M (52.4 M pairs, 2×150) | 32 | 44 min | ~39,600 reads/s (~2.4 M/min) | 371 MB |
+| reads | cores | wall time | throughput | peak RSS | clonotypes |
+|---|---|---|---|---|---|
+| 104.9 M (2×150) | 32 | 46 min | ~38,300 reads/s | 2,707 MB | 28,444 |
+| 153.9 M (2×100) | 32 | 51 min | ~50,300 reads/s | 511 MB | 1,519 |
+| 138.5 M (2×100) | 32 | 45 min | ~51,900 reads/s | 314 MB | 30 |
 
 Throughput scales roughly linearly with cores. The module is labelled `process_high`; for full-depth
 samples give it 16–32 cpus (`withName: 'ARDA' { cpus = 32 }`). `--threads` follows `task.cpus`.
+
+**Peak memory tracks repertoire richness, not read depth.** The third sample above has *more* reads
+than the first yet uses 9× less RAM — it has 30 clonotypes against 28,444. Mapping alone is flat and
+small (~300–400 MB at any depth); it is Stage 3 (assembly + error correction) that holds the clone set
+in memory. Budget **~4 GB** for a lymphocyte-rich or B-cell-rich sample and ~1 GB for a cold one; if
+you must cap tightly, `--no-assemble` returns to the flat mapping-only profile at the cost of the long
+CDR3s no single read spans.
 
 ## Requirements
 

--- a/integrations/nextflow/arda/main.nf
+++ b/integrations/nextflow/arda/main.nf
@@ -4,8 +4,10 @@
 
 process ARDA {
     tag "$meta.id"
-    // arda is CPU-bound (the MMseqs2 search dominates) but very low-memory (<400 MB, independent of
-    // depth) -- give it cores, not RAM. ~40k reads/s on 32 cores; a full-depth ~100M-read sample ~45 min.
+    // arda is CPU-bound: the MMseqs2 search dominates. ~40-50k reads/s on 32 cores; a full-depth
+    // ~100M-read sample takes ~45 min. Peak RSS tracks REPERTOIRE RICHNESS, not read depth -- mapping
+    // is flat (~300-400 MB at any depth), but Stage 3 holds the clone set, so a B-cell-rich tumour hit
+    // 2.7 GB at 28k clonotypes while a colder sample with MORE reads used 314 MB. Budget ~4 GB.
     label 'process_high'
 
     // arda is pip-installable (PyPI: arda-mapper) and needs the mmseqs2 binary.


### PR DESCRIPTION
The delivered docs claim arda is **"very low-memory (< 400 MB peak RSS, independent of read depth)"** in four places — README, `docs/pipeline_integration.rst`, and both the Nextflow module's README and its `process` comment.

That was measured before the Stage-3 assembler landed in 2.4.0. It is no longer true, and it is wrong in the direction that hurts: **Stage 3 holds the clone set in memory, so peak RSS follows repertoire richness.**

Measured at full depth, 32 cores, `arda rnaseq run --assemble`:

| reads | clonotypes | wall | peak RSS |
|---|---|---|---|
| 104.9 M (2×150) | 28,444 | 46 min | **2,707 MB** |
| 153.9 M (2×100) | 1,519 | 51 min | 511 MB |
| 138.5 M (2×100) | 30 | 45 min | **314 MB** |

The third sample has *more* reads than the first and uses 9× less RAM. Mapping alone is still flat (~300–400 MB at any depth) — it's the assembly + correction stage that scales.

Docs now say: budget **~4 GB** for a lymphocyte- or B-cell-rich sample, ~1 GB for a cold one, and `--no-assemble` restores the flat mapping-only profile under a hard memory cap.

Caught while collecting the 2.5.5 full-depth numbers. Someone sizing a SLURM or Nextflow memory directive off the old claim would have been OOM-killed on exactly the kind of sample arda exists for.

Docs build clean under `-W`.