### PR TITLE
Repin the Nextflow module and container refs to 2.5.6

### DIFF
--- a/docs/pipeline_integration.rst
+++ b/docs/pipeline_integration.rst
@@ -60,7 +60,7 @@ unchanged. Five edits, each mirroring how an existing tool is wired:
    ``workflows/rnaseq/nextflow.config`` (sets ``ext.args`` and the publishDir).
 #. Register a ``run_arda = false`` param in ``nextflow.config`` and ``nextflow_schema.json`` (strict
    schema validation).
-#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.5' }``
+#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.6' }``
    in your deployment config.
 
 Then run with ``--run_arda``. The module's ``README.md`` has copy-paste snippets and a standalone

--- a/integrations/nextflow/arda/Dockerfile
+++ b/integrations/nextflow/arda/Dockerfile
@@ -2,9 +2,9 @@
 # Build and push to your own registry (e.g. the ISPRAS private registry), then point the module's
 # `container` directive (or a withName override in your nextflow.config) at the pushed tag:
 #
-#   docker build -t arda-mapper:2.5.5 integrations/nextflow/arda
-#   docker tag arda-mapper:2.5.5 <your-registry>/arda-mapper:2.5.5
-#   docker push <your-registry>/arda-mapper:2.5.5
+#   docker build -t arda-mapper:2.5.6 integrations/nextflow/arda
+#   docker tag arda-mapper:2.5.6 <your-registry>/arda-mapper:2.5.6
+#   docker push <your-registry>/arda-mapper:2.5.6
 #
 FROM mambaorg/micromamba:1.5.8
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml

--- a/integrations/nextflow/arda/README.md
+++ b/integrations/nextflow/arda/README.md
@@ -98,7 +98,7 @@ changes. Five edits, all mirroring how an existing tool is wired:
    (copy any existing `skip_*`/`run_*` boolean entry as a template).
 
 5. **Container override** (only for `-profile docker/singularity/<your-profile>`): add
-   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.5' }` to your deployment config
+   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.6' }` to your deployment config
    (e.g. `conf/<profile>.config`), exactly as the other tools' images are pinned there.
 
 Run with `--run_arda`:

--- a/integrations/nextflow/arda/environment.yml
+++ b/integrations/nextflow/arda/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pip
   - pip:
       # seqtree (needed by `arda rnaseq correct`) is a core dependency since 2.5.5 -- no extra.
-      - arda-mapper==2.5.5
+      - arda-mapper==2.5.6

--- a/integrations/nextflow/arda/main.nf
+++ b/integrations/nextflow/arda/main.nf
@@ -15,7 +15,7 @@ process ARDA {
     //   -profile docker   -> build the image from the Dockerfile beside this module and push it to
     //                        your registry, then point `container` at it (or override in a config).
     conda "${moduleDir}/environment.yml"
-    container "arda-mapper:2.5.5"
+    container "arda-mapper:2.5.6"
 
     input:
     tuple val(meta), path(reads)


### PR DESCRIPTION
Follow-up to #73. `integrations/nextflow/arda/environment.yml` still pinned `arda-mapper==2.5.5`.

That is the pin that matters: **`-profile conda`** — the path the module's own README calls *"works out of the box"* — would have installed the release **without** the reference-fetch lock. Which is precisely the scenario #73 fixes: the Nextflow module launches one process per sample, and on a cold cache all of them fetch the reference into the same path at once.

Also bumps the Dockerfile build/tag/push examples, `main.nf`'s `container`, and the two docs that show the container pin.

The two remaining `2.5.5` mentions are historical statements ("a core dependency **since** 2.5.5", "an optional extra **before** 2.5.5") and are left alone.

Docs build clean under `-W`.