### PR TITLE
nf: derive --organism from params.genome, gate ARDA on supported assemblies

### DIFF
--- a/docs/pipeline_integration.rst
+++ b/docs/pipeline_integration.rst
@@ -111,8 +111,17 @@ set in memory. Budget **~4 GB** for a lymphocyte- or B-cell-rich sample and ~1 G
 a hard memory cap, ``--no-assemble`` restores the flat mapping-only profile — at the cost of the long
 CDR3s that no single read spans.
 
+Organism follows the genome
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The shipped ``nextflow.config`` reads ``params.genome`` — the iGenomes assembly key nf-core sets from
+``--genome`` — to both gate ARDA and choose its reference: ``GRCh38`` runs with ``--organism human``,
+``GRCm39`` with ``--organism mouse``, and any other (or unset) genome skips ARDA while the rest of the
+pipeline completes. arda ships full references only for human and mouse, so nothing else needs wiring.
+
 Tuning
 ~~~~~~~
 
-All arda flags pass through the module's ``ext.args`` (``--organism mouse``, ``--reconstruct``,
-``--min-score 0``, ``--kmer 11`` …). ``--threads`` is wired to ``task.cpus`` automatically.
+Extra arda flags pass through the module's ``ext.args`` (``--reconstruct``, ``--min-score 0``,
+``--kmer 11`` …); a static ``ext.args`` string overrides the genome-driven ``--organism`` default.
+``--threads`` is wired to ``task.cpus`` automatically.

--- a/integrations/nextflow/arda/README.md
+++ b/integrations/nextflow/arda/README.md
@@ -106,13 +106,28 @@ Run with `--run_arda`:
 nextflow run . -profile <your-profile> --input samplesheet.csv --outdir results --run_arda
 ```
 
+## Organism follows the genome automatically
+
+The shipped `nextflow.config` reads `params.genome` — the iGenomes assembly key nf-core sets from
+`--genome` — and both gates ARDA and picks its reference from it, so there is nothing extra to wire:
+
+| `--genome` | ARDA runs? | `--organism` |
+|---|---|---|
+| `GRCh38` | yes | `human` |
+| `GRCm39` | yes | `mouse` |
+| any other / unset | **skipped** (pipeline still completes) | — |
+
+Other assemblies are skipped because arda ships full references only for human and mouse. To force a
+different organism, or add a fifth column to the table below, override `ext.args` with a plain string
+(a static value replaces the genome-driven default).
+
 ## Tuning
 
-All arda flags pass through `ext.args` (set in `nextflow.config`). Common ones:
+All arda flags pass through `ext.args` (set in `nextflow.config`). Common overrides:
 
 | goal | `ext.args` |
 |---|---|
-| mouse reference | `--organism mouse` |
+| force mouse regardless of genome | `--organism mouse` |
 | merge overlapping mates first | `--organism human --reconstruct` |
 | keep every mapped read (recall-max) | `--organism human --min-score 0` |
 | cap memory harder / looser | `--organism human --kmer 11` (or `--kmer 0` for the mmseqs default) |

--- a/integrations/nextflow/arda/nextflow.config
+++ b/integrations/nextflow/arda/nextflow.config
@@ -1,9 +1,20 @@
 // Per-process config for the ARDA module. `includeConfig` this from your pipeline's config
 // (e.g. workflows/rnaseq/nextflow.config), mirroring how the other tool modules are wired.
+// arda ships references for human and mouse. Both hooks below read `params.genome` -- the iGenomes
+// assembly key nf-core sets from `--genome` -- so ARDA follows the assembly the rest of the pipeline
+// already runs on, with no extra parameter to configure:
+//   GRCh38 -> --organism human      GRCm39 -> --organism mouse      any other genome -> ARDA is skipped
 process {
     withName: 'ARDA' {
-        // arda run flags (organism, --reconstruct, --min-score, ...). Default: human.
-        ext.args = '--organism human'
+        // Run only on an assembly arda has a reference for. On any other genome ext.when is false and
+        // the process is skipped (main.nf's `when:` honours it), so the pipeline still completes.
+        ext.when = { params.genome in ['GRCh38', 'GRCm39'] }
+        // Map the assembly to arda's --organism. Append any extra arda flags here too, e.g.
+        //   params.genome == 'GRCh38' ? '--organism human --reconstruct' : ...
+        ext.args = {
+            params.genome == 'GRCh38' ? '--organism human' :
+            params.genome == 'GRCm39' ? '--organism mouse' : ''
+        }
         publishDir = [
             path: { "${params.outdir}/arda" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
Closes #75.

@EgorGuga requested that the Nextflow module's `nextflow.config`:
1. run ARDA only when `params.genome` is `GRCh38` or `GRCm39`, and
2. set `--organism` to `human` / `mouse` from the assembly.

The module's `main.nf` already honours both hooks this needs — `task.ext.when` (its `when:` block) and `task.ext.args` — so the change is entirely in the config, no module edit:

```groovy
ext.when = { params.genome in ['GRCh38', 'GRCm39'] }
ext.args = {
    params.genome == 'GRCh38' ? '--organism human' :
    params.genome == 'GRCm39' ? '--organism mouse' : ''
}
```

`params.genome` is the iGenomes key nf-core sets from `--genome`, so ARDA follows whatever assembly the rest of the pipeline is already running on — nothing extra to configure. Any other genome (or none) skips ARDA and the pipeline still completes.

### Verified end-to-end (not just parsed)

On aldan3 with real Nextflow (21.10.6), the **real module + this config**, and a fake `arda` on PATH that records its argv:

| `--genome` | ARDA runs? | `--organism` received |
|---|---|---|
| `GRCh38` | ✅ | `human` |
| `GRCm39` | ✅ | `mouse` |
| `GRCh37` | skipped | — |
| *(unset)* | skipped | — |

The skipped cases complete with no error; the two supported cases publish all four output files.

Docs updated (module `README.md` + `pipeline_integration.rst`): the genome→organism mapping, and that a static `ext.args` string overrides the genome-driven default. Sphinx `-W` build clean.