### PR TITLE
Rebuild a stale mmseqs cache instead of trusting its presence

### DIFF
--- a/src/arda/annotate/mapper.py
+++ b/src/arda/annotate/mapper.py
@@ -115,8 +115,17 @@ def _createdb_atomic(target_fasta: Path, db: Path, dbtype: int) -> None:
     So: hold the build lock, build into a private temp dir, and move the finished files into place
     with ``db`` **last** -- readers test ``db.exists()``, so it must not appear until its siblings are
     all there. A killed builder leaves a temp dir, never a half-built DB that looks complete.
+
+    "Done" means a **current** db, not merely a present one: an existing db OLDER than
+    ``target_fasta`` is stale and must be rebuilt. Gating on bare existence made a stale cache
+    permanent -- ``_cached_target_db`` decides to rebuild on mtime, then this guard sees the old
+    file, calls it done, and skips. The reference was rebuilt (e.g. `build-db`, or a pulled
+    `alleles.fasta`) but every run kept searching the previous scaffolds, silently shifting markup.
     """
-    with build_lock(db.parent / f".{db.name}.lock", done=db.exists) as ours:
+    def _current() -> bool:
+        return db.exists() and db.stat().st_mtime >= target_fasta.stat().st_mtime
+
+    with build_lock(db.parent / f".{db.name}.lock", done=_current) as ours:
         if not ours:
             return
         tmp = db.parent / f".{db.name}.tmp.{os.getpid()}"

--- a/tests/unit/test_index_concurrency.py
+++ b/tests/unit/test_index_concurrency.py
@@ -14,6 +14,7 @@ The invariant these tests pin: **any process that can see ``db`` must find it co
 """
 
 import multiprocessing as mp
+import os
 import time
 from pathlib import Path
 
@@ -108,3 +109,24 @@ def test_db_is_moved_into_place_last(tmp_path, monkeypatch):
     mapper._createdb_atomic(Path("/dev/null"), db, 2)
 
     assert moved[-1] == "db", f"`db` must be moved into place last; order was {moved}"
+
+
+def test_a_stale_cache_is_rebuilt(tmp_path, monkeypatch):
+    """A db OLDER than its source fasta is stale and must be rebuilt -- "done" means current, not present.
+
+    `_cached_target_db` decides staleness by mtime, then calls `_createdb_atomic` to rebuild. When the
+    build guard gated on bare existence, the stale file it found counted as done and the rebuild
+    silently no-op'd, so every run kept searching the previous scaffolds. Found as shifted mouse
+    markup: a 352-nt TRB scaffold cached under a reference since rebuilt to 346 nt, projecting the
+    346-nt coords through a 352-nt alignment and sliding the junction off Cys104.
+    """
+    fasta = tmp_path / "alleles.fasta"
+    fasta.write_text(">x\nACGT\n")
+    db = tmp_path / "db"
+    db.write_text("STALE")
+    old = fasta.stat().st_mtime - 100          # the cache predates its source -> stale
+    os.utime(db, (old, old))
+
+    monkeypatch.setattr(mmseqs, "createdb", lambda f, out, dbtype=2: Path(out).write_text("FRESH"))
+    mapper._createdb_atomic(fasta, db, 2)
+    assert db.read_text() == "FRESH", "a cache older than its source fasta was not rebuilt"


### PR DESCRIPTION
## Problem

Two mouse GenBank tests fail (`tests/unit/test_genbank_receptors.py::test_mouse_records_map_and_are_productive`, `test_mouse_fr4_agrees_between_vj_and_jc_scaffolds`): the mouse junction comes out one codon early, e.g. `junction_aa='LCASSFHRDYNSPL'` instead of the canonical `CASSFHRDYNSPLYF`.

## Root cause — a stale target-DB cache that never rebuilds

Not a transfer or reference-build bug. The committed `alleles.fasta` / `markup.tsv` are correct. The local `data/mmseqs_db/<org>_<seqtype>` cache held a **352-nt** `TRB_284` from an older reference, while the reference had since been rebuilt to **346 nt**. The runtime projected the 346-nt markup coords through an alignment against the stale 352-nt scaffold → 6 nt of drift → junction slides off Cys104.

`_cached_target_db` *does* detect the staleness (cache db mtime `<` `alleles.fasta` mtime) and calls `_createdb_atomic` to rebuild. But `_createdb_atomic` gated its "already built" check on `done=db.exists` (from the concurrency-safety refactor in `0fe3209`). The stale db file exists, so the guard called the work done and returned **without rebuilding**. The stale cache was effectively permanent.

This bites any user whose reference changes under an existing cache — a `build-db`, or a pulled `alleles.fasta`. `build-index` had the same latent skip after a `build-db`.

## Fix

"Done" now means a **current** db, not merely a present one: `db.exists() and db.stat().st_mtime >= target_fasta.stat().st_mtime`. A cache older than its source fasta is rebuilt; the concurrency guarantees (atomic temp-dir build, `db` moved into place last) are unchanged.

## Tests

- `tests/unit/test_index_concurrency.py::test_a_stale_cache_is_rebuilt` — new regression guard (fails without the fix: stale db exists → old guard skips → stays stale).
- Full CI set (`tests/unit tests/synthetic tests/realworld`) green: 302 passed; both mouse tests now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)