### PR TITLE
Release 2.5.7 — use the committed mmseqs indexes + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 Notable changes per release. Earlier releases are described by their git tags
 (`git tag --sort=-v:refname`); this file starts at 2.5.0.
 
+## 2.5.7
+
+### Fixed — a stale mmseqs cache was reused instead of rebuilt
+
+`_cached_target_db` detects a stale target DB by mtime (older than `alleles.fasta`) and calls
+`_createdb_atomic` to rebuild it — but that build guard gated "already built" on bare **existence**
+(`done=db.exists`, from the 2.5.5 concurrency work). So it found the stale file, called the work done,
+and skipped the rebuild: every run then searched the previous scaffolds, projecting the current
+`markup.tsv` coords through an out-of-date alignment and sliding the junction off Cys104. Surfaced as
+shifted mouse markup — a 352-nt TRB scaffold cached under a reference since rebuilt to 346 nt gave
+`junction_aa='LCASSFHRDYNSPL'` instead of `CASSFHRDYNSPLYF`. "Done" now means a *current* db (exists
+**and** at least as new as its source fasta); the same skip also affected `build-index` after a
+`build-db`.
+
+### Fixed — the committed precompiled indexes were never used
+
+The precompiled mmseqs DBs shipped in `database/vdj/*/mmseqs/` are gated on a version marker, compared
+with an exact `==`. But `mmseqs version` prints the same release+commit with different punctuation
+across builds — the official static binary says `18-8cc5c`, the bioconda build `18.8cc5c`. When the
+toolchain moved to the static binary, every committed marker (written under conda's mmseqs) stopped
+matching, so the shipped indexes were silently ignored and every run rebuilt a private cache. The
+comparison now uses a separator-insensitive `mmseqs.version_key` (folds `[\s._-]+`→`-`, lowercases),
+which bridges the cosmetic difference while still rejecting a genuinely different version.
+
+### Changed — dev/CI toolchain moved from conda to uv
+
+mmseqs2's bioconda binary was the only thing tying the dev environment to conda; it also ships an
+official static build, which arda already auto-fetches. `setup.sh` now builds a `uv` `.venv` (portable
+under bash and zsh) and CI installs via `uv`. Conda stays only for the Nextflow/ISP integration, which
+ships its own `environment.yml`. Does not affect `pip install arda-mapper`.
+
 ## 2.5.6
 
 ### Fixed — a concurrent fetch could publish a half-extracted reference

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 project = "arda"
 author = "Mikhail Shugay"
 copyright = "2026, Mikhail Shugay"
-release = "2.5.6"
+release = "2.5.7"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/pipeline_integration.rst
+++ b/docs/pipeline_integration.rst
@@ -60,7 +60,7 @@ unchanged. Five edits, each mirroring how an existing tool is wired:
    ``workflows/rnaseq/nextflow.config`` (sets ``ext.args`` and the publishDir).
 #. Register a ``run_arda = false`` param in ``nextflow.config`` and ``nextflow_schema.json`` (strict
    schema validation).
-#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.6' }``
+#. For container profiles, pin ``withName: 'ARDA' { container = '<registry>/arda-mapper:2.5.7' }``
    in your deployment config.
 
 Then run with ``--run_arda``. The module's ``README.md`` has copy-paste snippets and a standalone

--- a/integrations/nextflow/arda/Dockerfile
+++ b/integrations/nextflow/arda/Dockerfile
@@ -2,9 +2,9 @@
 # Build and push to your own registry (e.g. the ISPRAS private registry), then point the module's
 # `container` directive (or a withName override in your nextflow.config) at the pushed tag:
 #
-#   docker build -t arda-mapper:2.5.6 integrations/nextflow/arda
-#   docker tag arda-mapper:2.5.6 <your-registry>/arda-mapper:2.5.6
-#   docker push <your-registry>/arda-mapper:2.5.6
+#   docker build -t arda-mapper:2.5.7 integrations/nextflow/arda
+#   docker tag arda-mapper:2.5.7 <your-registry>/arda-mapper:2.5.7
+#   docker push <your-registry>/arda-mapper:2.5.7
 #
 FROM mambaorg/micromamba:1.5.8
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml

--- a/integrations/nextflow/arda/README.md
+++ b/integrations/nextflow/arda/README.md
@@ -98,7 +98,7 @@ changes. Five edits, all mirroring how an existing tool is wired:
    (copy any existing `skip_*`/`run_*` boolean entry as a template).
 
 5. **Container override** (only for `-profile docker/singularity/<your-profile>`): add
-   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.6' }` to your deployment config
+   `withName: 'ARDA' { container = '<your-registry>/arda-mapper:2.5.7' }` to your deployment config
    (e.g. `conf/<profile>.config`), exactly as the other tools' images are pinned there.
 
 Run with `--run_arda`:

--- a/integrations/nextflow/arda/environment.yml
+++ b/integrations/nextflow/arda/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pip
   - pip:
       # seqtree (needed by `arda rnaseq correct`) is a core dependency since 2.5.5 -- no extra.
-      - arda-mapper==2.5.6
+      - arda-mapper==2.5.7

--- a/integrations/nextflow/arda/main.nf
+++ b/integrations/nextflow/arda/main.nf
@@ -15,7 +15,7 @@ process ARDA {
     //   -profile docker   -> build the image from the Dockerfile beside this module and push it to
     //                        your registry, then point `container` at it (or override in a config).
     conda "${moduleDir}/environment.yml"
-    container "arda-mapper:2.5.6"
+    container "arda-mapper:2.5.7"
 
     input:
     tuple val(meta), path(reads)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arda-mapper"  # PyPI distribution name (`arda` is taken); imports as `arda`
-version = "2.5.6"
+version = "2.5.7"
 description = "Antigen Receptor Domain Annotation — fast TCR/BCR FR/CDR region annotation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/arda/__init__.py
+++ b/src/arda/__init__.py
@@ -6,7 +6,7 @@ via offline IgBLAST-built references mapped at runtime with MMseqs2.
 
 from __future__ import annotations
 
-__version__ = "2.5.6"
+__version__ = "2.5.7"
 
 from .adapter import annotate_sequences  # noqa: E402
 

--- a/src/arda/annotate/mapper.py
+++ b/src/arda/annotate/mapper.py
@@ -93,7 +93,7 @@ def _committed_index(organism: str, seqtype: str, target_fasta: Path | None = No
     if target_fasta is not None and db.stat().st_mtime < Path(target_fasta).stat().st_mtime:
         return None  # the reference was rebuilt after this index was compiled
     try:
-        if ver.read_text().strip() == mmseqs.version():
+        if mmseqs.version_key(ver.read_text()) == mmseqs.version_key(mmseqs.version()):
             return db
     except Exception:  # noqa: BLE001 — mmseqs missing; fall through to rebuild
         return None
@@ -180,7 +180,8 @@ def build_index(organism: str = "all", *, force: bool = False) -> None:
             # version alone made `build-index` a silent no-op after `build-db` rewrote alleles.fasta:
             # the rebuilt reference was never compiled, and the runtime kept searching the old one.
             fresh = db.exists() and db.stat().st_mtime >= fasta.stat().st_mtime
-            if fresh and not force and vfile.exists() and vfile.read_text().strip() == ver:
+            if fresh and not force and vfile.exists() and \
+                    mmseqs.version_key(vfile.read_text()) == mmseqs.version_key(ver):
                 continue
             out.mkdir(parents=True, exist_ok=True)
             # No unlink-then-rebuild: that deleted the files a concurrently-running arda was reading.

--- a/src/arda/mmseqs.py
+++ b/src/arda/mmseqs.py
@@ -13,6 +13,7 @@ is set — so neither pip nor conda users need to install mmseqs manually.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -25,6 +26,7 @@ __all__ = [
     "mmseqs_binary",
     "run",
     "version",
+    "version_key",
     "createdb",
     "search",
     "convertalis",
@@ -103,8 +105,25 @@ def run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
 
 @lru_cache(maxsize=1)
 def version() -> str:
-    """Return the mmseqs version string (e.g. ``18.8cc5c``)."""
+    """Return the mmseqs version string (e.g. ``18-8cc5c``)."""
     return run(["version"]).stdout.strip()
+
+
+def version_key(v: str) -> str:
+    """Canonical form of a version string, for comparing an index marker to the running mmseqs.
+
+    ``mmseqs version`` prints the same release+commit with different punctuation across builds:
+    the official static binary says ``18-8cc5c``, the bioconda build ``18.8cc5c``. They are the
+    same mmseqs and produce byte-compatible indexes; only the separator differs. Comparing the raw
+    strings with ``==`` therefore rejected every committed index the moment the toolchain moved from
+    conda's mmseqs to the static one -- so the precompiled DBs shipped in ``database/`` were never
+    used and every run rebuilt a private cache instead.
+
+    Fold each run of separator characters to a single ``-`` and lowercase. This bridges the cosmetic
+    difference while still distinguishing genuinely different versions (``17-b804f`` != ``18-8cc5c``),
+    so an incompatible index is never accepted.
+    """
+    return re.sub(r"[\s._-]+", "-", v.strip().lower())
 
 
 def createdb(fasta: str | Path, db: str | Path, *, dbtype: int | None = None) -> Path:

--- a/tests/unit/test_committed_index.py
+++ b/tests/unit/test_committed_index.py
@@ -1,0 +1,43 @@
+"""The precompiled mmseqs index shipped in ``database/`` is used only if it matches the running mmseqs.
+
+The match is on the version *marker*, and it was an exact string ``==``. But ``mmseqs version`` prints
+the same release+commit with different punctuation across builds -- the official static binary says
+``18-8cc5c``, the bioconda build ``18.8cc5c``. So the moment arda's toolchain moved from conda's
+mmseqs to the static one, every committed marker (written ``18.8cc5c``) stopped matching the runtime
+(``18-8cc5c``): the shipped indexes were silently never used and every run rebuilt a private cache.
+
+These pin the fix: a separator-insensitive key bridges the cosmetic difference without accepting a
+genuinely different version.
+"""
+
+from pathlib import Path
+
+from arda import mmseqs
+from arda.annotate import mapper
+
+
+def test_version_key_bridges_separators_not_versions():
+    assert mmseqs.version_key("18.8cc5c") == mmseqs.version_key("18-8cc5c")
+    assert mmseqs.version_key("  18-8CC5C\n") == "18-8cc5c"          # strip + lowercase
+    assert mmseqs.version_key("17-b804f") != mmseqs.version_key("18-8cc5c")
+
+
+def _fake_index(tmp_path: Path, marker: str) -> Path:
+    d = tmp_path / "mmseqs" / "nt"
+    d.mkdir(parents=True)
+    (d / "db").write_text("index")
+    (d / "VERSION").write_text(marker + "\n")
+    return tmp_path
+
+
+def test_committed_index_accepts_a_separator_variant_marker(tmp_path, monkeypatch):
+    """A ``18.8cc5c`` marker must satisfy a ``18-8cc5c`` runtime -- the exact case the bug rejected."""
+    monkeypatch.setattr(mapper, "vdj_dir", lambda org: _fake_index(tmp_path, "18.8cc5c"))
+    monkeypatch.setattr(mapper.mmseqs, "version", lambda: "18-8cc5c")
+    assert mapper._committed_index("x", "nt") is not None
+
+
+def test_committed_index_rejects_a_different_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(mapper, "vdj_dir", lambda org: _fake_index(tmp_path, "17-b804f"))
+    monkeypatch.setattr(mapper.mmseqs, "version", lambda: "18-8cc5c")
+    assert mapper._committed_index("x", "nt") is None


### PR DESCRIPTION
Cuts **2.5.7**. Headline fix + the version bump; the reference is unchanged.

## Fix — the committed precompiled indexes were never used

The precompiled mmseqs DBs shipped in `database/vdj/*/mmseqs/` are gated on a version marker compared with an exact `==`. But `mmseqs version` prints the same release+commit with different punctuation across builds — the official static binary says `18-8cc5c`, the bioconda build `18.8cc5c`. When arda's toolchain moved from conda's mmseqs to the static binary (#78), every committed marker (written under conda's mmseqs) stopped matching, so the shipped indexes were silently ignored and every run rebuilt a private `data/mmseqs_db` cache.

`_committed_index` and `build_index` now compare via `mmseqs.version_key` — folds `[\s._-]+`→`-` and lowercases — bridging the cosmetic difference while still rejecting a genuinely different version (`17-b804f` ≠ `18-8cc5c`). Verified: the committed nt/aa indexes for every org are now selected, and the full unit + synthetic + realworld suite is green **using them** (303 passed).

## Version bump 2.5.6 → 2.5.7

All eight places: `pyproject.toml`, `src/arda/__init__.py`, `docs/conf.py`, `docs/pipeline_integration.rst`, and the Nextflow module's `main.nf` / `environment.yml` / `Dockerfile` / `README.md`. The `pypi` publish job validates pyproject == tag.

## CHANGELOG

`## 2.5.7` covers this fix plus the two already-merged into master since 2.5.6: the stale-cache rebuild (#77) and the conda→uv toolchain switch (#78).

## Release checklist
- [x] `scripts/pack_reference.sh` pre-flighted locally (2.8M, 53 members, verified — the `reference-asset` job will attach `arda-reference-vdj.tar.gz`)
- [ ] Merge → cut GitHub Release `v2.5.7` → `publish.yml` builds wheels/sdist and pauses at the **`pypi`** environment gate for approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)